### PR TITLE
performance changes for pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+All notable changes to the 1.36-develop branch will be documented in this file.
+
+## [Unreleased]
+
+## [1.47] - 2017-11-27
+## Changed
+- Disable AWS slave count cache by default. Use hudson.plugins.ec2.EC2Cloud.cachettl to specify cache in milliseconds
+
+## [1.46] - 2017-11-13
+### Added
+- Timeout slave after max connect time has been reached (improvement for T2 AWS tiers). Use hudson.plugins.ec2.EC2RetentionStrategy.maxConnectTimeSeconds
+### Changed
+- Skip idle timeout check if slave connect time is less than 5 minutes (improvment for Jenkins master startup)
+
+## [1.45] - 2017-11-13
+### Changed
+- Disconnect Jenkins from the slave before shutting down the slave
+- Only shutdown online Jenkins slaves (skip shutting down stopped slaves)
+
+## [1.44] - 2017-10-31
+### Added
+- Cache AWS slave count 10 minutes when last value from AWS is 0
+- Null pointer check on bootstrap connections backported from 1.37
+- If we are unable to SSH into a slave because it is stopped, start the slave
+### Changed
+- Don't count stopped slaves as an existing node available for work
+- Don't count VMs in AWS if configured EC2 Plugin cloud instance cap is 10000+
+- Don't try to create a slave when we have 0 capacity
+- Since getNewOrExistingAvailableSlave returns the same slave, only start it once
+- When using billable hour retention, only shutdown a slave if it's at the end of the billable hour and has been idle 30 seconds
+- Only run the slave monitor thread when there are no busy executors
+
+## [1.40] - 2017-9-6
+### Changed
+- Obtain SSH key once during slave node startup cycle
+- Use cached AWS state for better performance (describeInstance vs updateInstanceDescription)
+### Removed
+- Removed unused bootstrapConn variable reference

--- a/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AbstractSlave.java
@@ -295,12 +295,15 @@ public abstract class EC2AbstractSlave extends Slave {
 
     void stop() {
         try {
+            if (!toComputer().isIdle()) {
+                LOGGER.log(Level.WARNING, "Attempting to stop a busy EC2 instance: " + getInstanceId());
+            }
+            toComputer().disconnect(null);
             AmazonEC2 ec2 = getCloud().connect();
             StopInstancesRequest request = new StopInstancesRequest(Collections.singletonList(getInstanceId()));
             LOGGER.fine("Sending stop request for " + getInstanceId());
             ec2.stopInstances(request);
             LOGGER.info("EC2 instance stop request sent for " + getInstanceId());
-            toComputer().disconnect(null);
         } catch (AmazonClientException e) {
             Instance i = getInstance(getInstanceId(), getCloud());
             LOGGER.log(Level.WARNING, "Failed to stop EC2 instance: " + getInstanceId() + " info: "

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -149,7 +149,7 @@ public abstract class EC2Cloud extends Cloud {
     
     private static List<long[]> countCache = new ArrayList<long[]>(Arrays.asList(new long[] {1000, 1000}));
     
-    private static final int CACHE_TTL_DEFAULT = 600000; //10 minutes
+    private static final int CACHE_TTL_DEFAULT = 0; //disabled by default
     
     private static final int cacheTTL = NumberUtils.toInt(
             System.getProperty(EC2Cloud.class.getCanonicalName() + ".cachettl",

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -101,7 +101,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
             return 1;
         }
 
-        LOGGER.finest("Master uptime is: " + String.valueOf(masterUptime));
+        LOGGER.finest("Master uptime is: " + masterUptime.getUptime());
         if (computer.isIdle() && !DISABLED && !computer.isConnecting() && masterUptime.getUptime() > 300000) {
             final long uptime;
             try {

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -61,7 +61,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
     private static final int MAX_UPTIME_SEC = NumberUtils.toInt(
             System.getProperty(EC2RetentionStrategy.class.getCanonicalName() + ".maxUptimeSeconds",
                     String.valueOf(Integer.MAX_VALUE)), Integer.MAX_VALUE);
-    jenkins.model.Uptime masterUptime = new jenkins.model.Uptime();
+    private static final jenkins.model.Uptime masterUptime = new jenkins.model.Uptime();
 
     @DataBoundConstructor
     public EC2RetentionStrategy(String idleTerminationMinutes) {

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -101,8 +101,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
             return 1;
         }
 
-        LOGGER.finest("Master uptime is: " + (System.currentTimeMillis() - masterUptime.getUptime()) );
-        if (computer.isIdle() && !DISABLED && !computer.isConnecting() && (System.currentTimeMillis() - masterUptime.getUptime()) > 300000) {
+        if (computer.isIdle() && !DISABLED && !computer.isConnecting()) {
             final long uptime;
             try {
                 uptime = computer.getUptime(); 
@@ -118,7 +117,8 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
                 return 1;
             }
             final long idleMilliseconds = System.currentTimeMillis() - computer.getIdleStartMilliseconds();
-            if (idleTerminationMinutes > 0) {
+            LOGGER.finest("Master uptime is: " + (System.currentTimeMillis() - masterUptime.getUptime()) );
+            if (idleTerminationMinutes > 0 && (System.currentTimeMillis() - masterUptime.getUptime()) > 300000) {
                 // TODO: really think about the right strategy here, see
                 // JENKINS-23792
                 if (idleMilliseconds > TimeUnit2.MINUTES.toMillis(idleTerminationMinutes)) {

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -100,11 +100,12 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
             return 1;
         }
 
-
-        if (computer.isIdle() && !DISABLED && !computer.isConnecting()) {
+        jenkins.model.Uptime masterUptime = new jenkins.model.Uptime();
+        LOGGER.finest("Master uptime is: " + masterUptime);
+        if (computer.isIdle() && !DISABLED && !computer.isConnecting() && masterUptime.getUptime() > 300000) {
             final long uptime;
             try {
-                uptime = computer.getUptime();
+                uptime = computer.getUptime(); 
             } catch (AmazonClientException | InterruptedException e) {
                 // We'll just retry next time we test for idleness.
                 LOGGER.fine("Exception while checking host uptime for " + computer.getName()

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -58,6 +58,9 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
     private static final int STARTUP_TIMEOUT = NumberUtils.toInt(
             System.getProperty(EC2RetentionStrategy.class.getCanonicalName() + ".startupTimeout",
                     String.valueOf(STARTUP_TIME_DEFAULT_VALUE)), STARTUP_TIME_DEFAULT_VALUE);
+    private static final int MAX_UPTIME_MINS = NumberUtils.toInt(
+            System.getProperty(EC2RetentionStrategy.class.getCanonicalName() + ".maxuptime",
+                    String.valueOf(Integer.MAX_VALUE)), Integer.MAX_VALUE);
 
     @DataBoundConstructor
     public EC2RetentionStrategy(String idleTerminationMinutes) {
@@ -120,6 +123,11 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
                 if (idleMilliseconds > TimeUnit2.MINUTES.toMillis(idleTerminationMinutes)) {
                     LOGGER.info("Idle timeout of " + computer.getName() + " after "
                             + TimeUnit2.MILLISECONDS.toMinutes(idleMilliseconds) + " idle minutes");
+                    computer.getNode().idleTimeout();
+                } else if (uptime > TimeUnit2.MINUTES.toMillis(MAX_UPTIME_MINS)) {
+                    LOGGER.info("Idle timeout of " + computer.getName() + " since uptime "
+                            + TimeUnit2.MILLISECONDS.toMinutes(uptime) + " mins exceeds "
+                            + MAX_UPTIME_MINS + " mins");
                     computer.getNode().idleTimeout();
                 }
             } else {

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -61,8 +61,6 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
     private static final int MAX_UPTIME_SEC = NumberUtils.toInt(
             System.getProperty(EC2RetentionStrategy.class.getCanonicalName() + ".maxUptimeSeconds",
                     String.valueOf(Integer.MAX_VALUE)), Integer.MAX_VALUE);
-    private static final jenkins.model.Uptime masterUptime = new jenkins.model.Uptime();
-    private static final long masterUptimeInMillis = masterUptime.getUptime();
 
     @DataBoundConstructor
     public EC2RetentionStrategy(String idleTerminationMinutes) {
@@ -118,15 +116,15 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
                 return 1;
             }
             final long idleMilliseconds = System.currentTimeMillis() - computer.getIdleStartMilliseconds();
-            LOGGER.finest("Master uptime is: " + (System.currentTimeMillis() - masterUptimeInMillis) );
-            if (idleTerminationMinutes > 0 && (System.currentTimeMillis() - masterUptimeInMillis) > 300000) {
+            LOGGER.finest("Slave connect time is: " + (System.currentTimeMillis() - computer.getConnectTime()) );
+            if (idleTerminationMinutes > 0 && (System.currentTimeMillis() - computer.getConnectTime()) > 300000) {
                 // TODO: really think about the right strategy here, see
                 // JENKINS-23792
                 if (idleMilliseconds > TimeUnit2.MINUTES.toMillis(idleTerminationMinutes)) {
                     LOGGER.info("Idle timeout of " + computer.getName() + " after "
                             + TimeUnit2.MILLISECONDS.toMinutes(idleMilliseconds) + " idle minutes");
                     computer.getNode().idleTimeout();
-                } else if (uptime > TimeUnit2.SECONDS.toMillis(MAX_UPTIME_SEC)) {
+                } else if (computer.getConnectTime() > TimeUnit2.SECONDS.toMillis(MAX_UPTIME_SEC)) {
                     LOGGER.info("Idle timeout of " + computer.getName() + " since uptime "
                             + TimeUnit2.MILLISECONDS.toMinutes(uptime) + " mins exceeds "
                             + TimeUnit2.SECONDS.toMinutes(MAX_UPTIME_SEC) + " mins");

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -119,6 +119,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
             final long connectMilliseconds = System.currentTimeMillis() - computer.getConnectTime();
             LOGGER.finest("Slave connect time is: " + connectMilliseconds);
             if (idleTerminationMinutes > 0 && connectMilliseconds > 300000) {
+                // don't timeout slave if it has been connected less than 5 minutes
                 // TODO: really think about the right strategy here, see
                 // JENKINS-23792
                 if (idleMilliseconds > TimeUnit2.MINUTES.toMillis(idleTerminationMinutes)) {

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -61,7 +61,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
     private static final int MAX_UPTIME_SEC = NumberUtils.toInt(
             System.getProperty(EC2RetentionStrategy.class.getCanonicalName() + ".maxUptimeSeconds",
                     String.valueOf(Integer.MAX_VALUE)), Integer.MAX_VALUE);
-    private static final long STARTUP_TIME = System.currentTimeMillis();
+    jenkins.model.Uptime masterUptime = new jenkins.model.Uptime();
 
     @DataBoundConstructor
     public EC2RetentionStrategy(String idleTerminationMinutes) {
@@ -101,7 +101,8 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
             return 1;
         }
 
-        if (computer.isIdle() && !DISABLED && !computer.isConnecting() && (STARTUP_TIME - System.currentTimeMillis())  > 300000) {
+        LOGGER.finest("Master uptime is: " + String.valueOf(masterUptime));
+        if (computer.isIdle() && !DISABLED && !computer.isConnecting() && masterUptime.getUptime() > 300000) {
             final long uptime;
             try {
                 uptime = computer.getUptime(); 

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -101,7 +101,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
         }
 
 
-        if (computer.isIdle() && !DISABLED) {
+        if (computer.isIdle() && !DISABLED && !computer.isConnecting()) {
             final long uptime;
             try {
                 uptime = computer.getUptime();

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -61,6 +61,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
     private static final int MAX_UPTIME_SEC = NumberUtils.toInt(
             System.getProperty(EC2RetentionStrategy.class.getCanonicalName() + ".maxUptimeSeconds",
                     String.valueOf(Integer.MAX_VALUE)), Integer.MAX_VALUE);
+    private static final long STARTUP_TIME = System.currentTimeMillis();
 
     @DataBoundConstructor
     public EC2RetentionStrategy(String idleTerminationMinutes) {
@@ -100,9 +101,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
             return 1;
         }
 
-        jenkins.model.Uptime masterUptime = new jenkins.model.Uptime();
-        LOGGER.finest("Master uptime is: " + masterUptime);
-        if (computer.isIdle() && !DISABLED && !computer.isConnecting() && masterUptime.getUptime() > 300000) {
+        if (computer.isIdle() && !DISABLED && !computer.isConnecting() && (STARTUP_TIME - System.currentTimeMillis())  > 300000) {
             final long uptime;
             try {
                 uptime = computer.getUptime(); 

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -101,8 +101,8 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
             return 1;
         }
 
-        LOGGER.finest("Master uptime is: " + masterUptime.getUptime());
-        if (computer.isIdle() && !DISABLED && !computer.isConnecting() && masterUptime.getUptime() > 300000) {
+        LOGGER.finest("Master uptime is: " + (System.currentTimeMillis() - masterUptime.getUptime()) );
+        if (computer.isIdle() && !DISABLED && !computer.isConnecting() && (System.currentTimeMillis() - masterUptime.getUptime()) > 300000) {
             final long uptime;
             try {
                 uptime = computer.getUptime(); 

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -58,7 +58,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
     private static final int STARTUP_TIMEOUT = NumberUtils.toInt(
             System.getProperty(EC2RetentionStrategy.class.getCanonicalName() + ".startupTimeout",
                     String.valueOf(STARTUP_TIME_DEFAULT_VALUE)), STARTUP_TIME_DEFAULT_VALUE);
-    private static final int MAX_UPTIME_SEC = NumberUtils.toInt(
+    private static final int MAX_CONNECT_SEC = NumberUtils.toInt(
             System.getProperty(EC2RetentionStrategy.class.getCanonicalName() + ".maxConnectTimeSeconds",
                     String.valueOf(Integer.MAX_VALUE)), Integer.MAX_VALUE);
 
@@ -127,12 +127,12 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
                     LOGGER.info("Idle timeout of " + computer.getName() + " after "
                             + TimeUnit2.MILLISECONDS.toMinutes(idleMilliseconds) + " idle minutes");
                     computer.getNode().idleTimeout();
-                } else if (connectMilliseconds > TimeUnit2.SECONDS.toMillis(MAX_UPTIME_SEC)) {
+                } else if (connectMilliseconds > TimeUnit2.SECONDS.toMillis(MAX_CONNECT_SEC)) {
                     // timeout slave if max connect time has been reached
                     // useful if you are using T2 AWS tiers
                     LOGGER.info("Connect timeout of " + computer.getName() + " - connect time "
                             + TimeUnit2.MILLISECONDS.toMinutes(connectMilliseconds) + " mins exceeds "
-                            + TimeUnit2.SECONDS.toMinutes(MAX_UPTIME_SEC) + " min max");
+                            + TimeUnit2.SECONDS.toMinutes(MAX_CONNECT_SEC) + " min max");
                     computer.getNode().idleTimeout();
                 }
             } else {

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -126,6 +126,8 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
                             + TimeUnit2.MILLISECONDS.toMinutes(idleMilliseconds) + " idle minutes");
                     computer.getNode().idleTimeout();
                 } else if (connectMilliseconds > TimeUnit2.SECONDS.toMillis(MAX_UPTIME_SEC)) {
+                    // timeout slave if max connect time has been reached
+                    // useful if you are using T2 AWS tiers
                     LOGGER.info("Connect timeout of " + computer.getName() + " since uptime "
                             + TimeUnit2.MILLISECONDS.toMinutes(connectMilliseconds) + " mins exceeds "
                             + TimeUnit2.SECONDS.toMinutes(MAX_UPTIME_SEC) + " mins");

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -91,9 +91,9 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
 
     private long internalCheck(EC2Computer computer) {
         /*
-        * If we've been told never to terminate, or node is null(deleted), no checks to perform
+        * If we've been told never to terminate, or node is null(deleted), or node is offline, no checks to perform
         */
-        if (idleTerminationMinutes == 0 || computer.getNode() == null) {
+        if (idleTerminationMinutes == 0 || computer.getNode() == null || computer.isOffline()) {
             return 1;
         }
 

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -62,6 +62,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
             System.getProperty(EC2RetentionStrategy.class.getCanonicalName() + ".maxUptimeSeconds",
                     String.valueOf(Integer.MAX_VALUE)), Integer.MAX_VALUE);
     private static final jenkins.model.Uptime masterUptime = new jenkins.model.Uptime();
+    private static final long masterUptimeInMillis = masterUptime.getUptime();
 
     @DataBoundConstructor
     public EC2RetentionStrategy(String idleTerminationMinutes) {
@@ -117,8 +118,8 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
                 return 1;
             }
             final long idleMilliseconds = System.currentTimeMillis() - computer.getIdleStartMilliseconds();
-            LOGGER.finest("Master uptime is: " + (System.currentTimeMillis() - masterUptime.getUptime()) );
-            if (idleTerminationMinutes > 0 && (System.currentTimeMillis() - masterUptime.getUptime()) > 300000) {
+            LOGGER.finest("Master uptime is: " + (System.currentTimeMillis() - masterUptimeInMillis) );
+            if (idleTerminationMinutes > 0 && (System.currentTimeMillis() - masterUptimeInMillis) > 300000) {
                 // TODO: really think about the right strategy here, see
                 // JENKINS-23792
                 if (idleMilliseconds > TimeUnit2.MINUTES.toMillis(idleTerminationMinutes)) {

--- a/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
+++ b/src/main/java/hudson/plugins/ec2/EC2RetentionStrategy.java
@@ -58,8 +58,8 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
     private static final int STARTUP_TIMEOUT = NumberUtils.toInt(
             System.getProperty(EC2RetentionStrategy.class.getCanonicalName() + ".startupTimeout",
                     String.valueOf(STARTUP_TIME_DEFAULT_VALUE)), STARTUP_TIME_DEFAULT_VALUE);
-    private static final int MAX_UPTIME_MINS = NumberUtils.toInt(
-            System.getProperty(EC2RetentionStrategy.class.getCanonicalName() + ".maxuptime",
+    private static final int MAX_UPTIME_SEC = NumberUtils.toInt(
+            System.getProperty(EC2RetentionStrategy.class.getCanonicalName() + ".maxUptimeSeconds",
                     String.valueOf(Integer.MAX_VALUE)), Integer.MAX_VALUE);
 
     @DataBoundConstructor
@@ -124,10 +124,10 @@ public class EC2RetentionStrategy extends RetentionStrategy<EC2Computer> {
                     LOGGER.info("Idle timeout of " + computer.getName() + " after "
                             + TimeUnit2.MILLISECONDS.toMinutes(idleMilliseconds) + " idle minutes");
                     computer.getNode().idleTimeout();
-                } else if (uptime > TimeUnit2.MINUTES.toMillis(MAX_UPTIME_MINS)) {
+                } else if (uptime > TimeUnit2.SECONDS.toMillis(MAX_UPTIME_SEC)) {
                     LOGGER.info("Idle timeout of " + computer.getName() + " since uptime "
                             + TimeUnit2.MILLISECONDS.toMinutes(uptime) + " mins exceeds "
-                            + MAX_UPTIME_MINS + " mins");
+                            + TimeUnit2.SECONDS.toMinutes(MAX_UPTIME_SEC) + " mins");
                     computer.getNode().idleTimeout();
                 }
             } else {

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -23,6 +23,8 @@ public class EC2RetentionStrategyTest {
     @Test
     public void testOnBillingHourRetention() throws Exception {
         EC2RetentionStrategy rs = new EC2RetentionStrategy("-2");
+        //Sleep 5 mins for uptime
+        Thread.sleep(300000);
         List<int[]> upTime = new ArrayList<int[]>();
         List<Boolean> expected = new ArrayList<Boolean>();
         upTime.add(new int[] { 58, 0 });

--- a/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2RetentionStrategyTest.java
@@ -23,8 +23,6 @@ public class EC2RetentionStrategyTest {
     @Test
     public void testOnBillingHourRetention() throws Exception {
         EC2RetentionStrategy rs = new EC2RetentionStrategy("-2");
-        //Sleep 5 mins for uptime
-        Thread.sleep(300000);
         List<int[]> upTime = new ArrayList<int[]>();
         List<Boolean> expected = new ArrayList<Boolean>();
         upTime.add(new int[] { 58, 0 });


### PR DESCRIPTION
## [1.47] - 2017-11-27
## Changed
- Disable AWS slave count cache by default. Use hudson.plugins.ec2.EC2Cloud.cachettl to specify cache in milliseconds

## [1.46] - 2017-11-13
### Added
- Timeout slave after max connect time has been reached (improvement for T2 AWS tiers). Use hudson.plugins.ec2.EC2RetentionStrategy.maxConnectTimeSeconds
### Changed
- Skip idle timeout check if slave connect time is less than 5 minutes (improvment for Jenkins master startup)

## [1.45] - 2017-11-13
### Changed
- Disconnect Jenkins from the slave before shutting down the slave
- Only shutdown online Jenkins slaves (skip shutting down stopped slaves)