### PR TITLE
Add ability to use T2 Unlimited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
-All notable changes to the 2.0-develop branch will be documented in this file.
+All notable changes to the 2.1-develop branch will be documented in this file.
 
 ## [Unreleased]
+
+## [2.10] - 2018-10-16
+### Added
+- Use startup property hudson.plugins.ec2.t2unlimited=true to enable T2 Unlimited
+### Changed
+- Requires Jenkins AWS Java SDK plugin version 1.11.248 or newer
 
 ## [2.00] - 2018-02-28
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.119</version>
+            <version>1.11.248</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -126,7 +126,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public final boolean connectUsingPublicIp;
     
-    public static final String creditSpecification = System.getProperty("hudson.plugins.ec2.cpucredits","standard");
+    public static final String t2CreditType = System.getProperty("hudson.plugins.ec2.t2credittype","standard");
 
     private transient/* almost final */Set<LabelAtom> labelSet;
 
@@ -590,9 +590,9 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 if (StringUtils.isNotBlank(getIamInstanceProfile())) {
                     riRequest.setIamInstanceProfile(new IamInstanceProfileSpecification().withArn(getIamInstanceProfile()));
                 }
-                // For T2 and T3 instances, set CPU credit option accordingly
-                if (type.toString().toLowerCase().startsWith("t"))
-                    riRequest.getCreditSpecification().setCpuCredits(creditSpecification);
+                // For T2 instances, set CPU credit type accordingly
+                if (type.toString().toLowerCase().startsWith("t2")) {
+                    riRequest.setCreditSpecification(new CreditSpecificationRequest().withCpuCredits(t2CreditType));
                 }
                 // Have to create a new instance
                 Instance inst = ec2.runInstances(riRequest).getReservation().getInstances().get(0);

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -591,7 +591,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                     riRequest.setIamInstanceProfile(new IamInstanceProfileSpecification().withArn(getIamInstanceProfile()));
                 }
                 // For T2 instances, set CPU credit type accordingly
-                if (type.toString().toLowerCase().startsWith("t2") && t2Unlimited) {
+                if (t2Unlimited && type.toString().toLowerCase().startsWith("t2")) {
                     riRequest.setCreditSpecification(new CreditSpecificationRequest().withCpuCredits("unlimited"));
                 }
                 // Have to create a new instance

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -125,6 +125,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     public boolean connectBySSHProcess;
 
     public final boolean connectUsingPublicIp;
+    
+    public static final String creditSpecification = System.getProperty("hudson.plugins.ec2.cpucredits","standard");
 
     private transient/* almost final */Set<LabelAtom> labelSet;
 
@@ -587,6 +589,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 }
                 if (StringUtils.isNotBlank(getIamInstanceProfile())) {
                     riRequest.setIamInstanceProfile(new IamInstanceProfileSpecification().withArn(getIamInstanceProfile()));
+                }
+                // For T2 and T3 instances, set CPU credit option accordingly
+                if (type.toString().toLowerCase().startsWith("t"))
+                    riRequest.getCreditSpecification().setCpuCredits(creditSpecification);
                 }
                 // Have to create a new instance
                 Instance inst = ec2.runInstances(riRequest).getReservation().getInstances().get(0);

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -126,7 +126,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public final boolean connectUsingPublicIp;
     
-    public static final String t2CreditType = System.getProperty("hudson.plugins.ec2.t2credittype","standard");
+    public static final boolean t2Unlimited = Boolean.parseBoolean(System.getProperty("hudson.plugins.ec2.t2unlimited","false"));
 
     private transient/* almost final */Set<LabelAtom> labelSet;
 
@@ -591,8 +591,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                     riRequest.setIamInstanceProfile(new IamInstanceProfileSpecification().withArn(getIamInstanceProfile()));
                 }
                 // For T2 instances, set CPU credit type accordingly
-                if (type.toString().toLowerCase().startsWith("t2")) {
-                    riRequest.setCreditSpecification(new CreditSpecificationRequest().withCpuCredits(t2CreditType));
+                if (type.toString().toLowerCase().startsWith("t2") && t2Unlimited) {
+                    riRequest.setCreditSpecification(new CreditSpecificationRequest().withCpuCredits("unlimited"));
                 }
                 // Have to create a new instance
                 Instance inst = ec2.runInstances(riRequest).getReservation().getInstances().get(0);


### PR DESCRIPTION
Currently the EC2 plugin uses the "standard" T2 CPU credit option.  This change allows for the credit option to utilize "unlimited" for T2 instance types.  Since T3 already has "unlimited" enabled by default, this only needs to apply to T2 types.  The default should continue to be "standard".  

Add the Java argument below to enable T2 "unlimited".

-Dhudson.plugins.ec2.t2unlimited=true